### PR TITLE
Team based boost mod

### DIFF
--- a/source/RocketPlugin.cpp
+++ b/source/RocketPlugin.cpp
@@ -14,6 +14,7 @@
 #include "gamemodes/KeepAway.h"
 #include "gamemodes/Tag.h"
 #include "gamemodes/Juggernaut.h"
+#include "gamemodes/BoostMod.h"
 
 BAKKESMOD_PLUGIN(RocketPlugin, "Rocket Plugin", "0.6.3", 0x0)
 
@@ -1769,6 +1770,7 @@ void RocketPlugin::onLoad()
     gamemodes.push_back(std::shared_ptr<RocketGameMode>(new KeepAway(this)));
     gamemodes.push_back(std::shared_ptr<RocketGameMode>(new Tag(this)));
     gamemodes.push_back(std::shared_ptr<RocketGameMode>(new Juggernaut(this)));
+    gamemodes.push_back(std::shared_ptr<RocketGameMode>(new BoostMod(this)));
 }
 
 

--- a/source/RocketPlugin.cpp
+++ b/source/RocketPlugin.cpp
@@ -1770,7 +1770,7 @@ void RocketPlugin::onLoad()
     gamemodes.push_back(std::shared_ptr<RocketGameMode>(new KeepAway(this)));
     gamemodes.push_back(std::shared_ptr<RocketGameMode>(new Tag(this)));
     gamemodes.push_back(std::shared_ptr<RocketGameMode>(new Juggernaut(this)));
-    gamemodes.push_back(std::shared_ptr<RocketGameMode>(new BoostMod(this)));
+    gamemodes.push_back(std::make_shared<BoostMod>(this));
 }
 
 

--- a/source/RocketPlugin.vcxproj
+++ b/source/RocketPlugin.vcxproj
@@ -107,6 +107,7 @@
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="gamemodes\BoostMod.h" />
     <ClInclude Include="Networking.h" />
     <ClInclude Include="RocketPlugin.h" />
     <ClInclude Include="bakkesmod_additions\cvarmanagerwrapperdebug.h" />
@@ -129,6 +130,7 @@
     <ClInclude Include="imgui\imstb_truetype.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="gamemodes\BoostMod.cpp" />
     <ClCompile Include="Networking.cpp" />
     <ClCompile Include="P2PHost.cpp" />
     <ClCompile Include="UPnPClient.cpp" />

--- a/source/RocketPlugin.vcxproj.filters
+++ b/source/RocketPlugin.vcxproj.filters
@@ -84,6 +84,9 @@
     <ClInclude Include="bakkesmod_additions\parser.h">
       <Filter>Resource Files\BakkesMod additions</Filter>
     </ClInclude>
+    <ClInclude Include="gamemodes\BoostMod.h">
+      <Filter>Resource Files\Gamemodes</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="RocketPlugin.cpp">
@@ -145,6 +148,9 @@
     </ClCompile>
     <ClCompile Include="ExternalFunctions.cpp">
       <Filter>Resource Files</Filter>
+    </ClCompile>
+    <ClCompile Include="gamemodes\BoostMod.cpp">
+      <Filter>Resource Files\Gamemodes</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/source/gamemodes/BoostMod.cpp
+++ b/source/gamemodes/BoostMod.cpp
@@ -63,7 +63,7 @@ void BoostMod::onTick(ServerWrapper server, void*)
 void BoostMod::RenderSingleOption(BoostModValues& boostSettings)
 {
 	ImGui::Spacing();
-	if (ImGui::SwitchCheckbox((" Enable " + boostSettings.displaySuffix).c_str(), 
+	if (ImGui::SwitchCheckbox(" Enable ", 
 		boostSettings.enabled)) 
 	{
 		boostSettings.enabled = !boostSettings.enabled;
@@ -71,13 +71,13 @@ void BoostMod::RenderSingleOption(BoostModValues& boostSettings)
 	if (boostSettings.enabled) {
 		//TODO: implement boost amount type modifier.
 		//ImGui::SliderArray(("Boost Amount Type" + boostSettings.displaySuffix).c_str(), &boostSettings.boostAmountType, boostAmounts);
-		ImGui::SliderInt(("Boost Limit " + boostSettings.displaySuffix).c_str(),
+		ImGui::SliderInt("Boost Limit ",
 			&boostSettings.maxBoost, 0, 100, "%d%%");
 	}
 	else {
 		ImGui::BeginDisabled();
 		//ImGui::SliderArray(("Boost Amount Type" + boostSettings.displaySuffix).c_str(), &boostSettings.boostAmountType, boostAmounts);
-		ImGui::SliderInt(("Boost Limit " + boostSettings.displaySuffix).c_str(), &boostSettings.maxBoost, 0, 100, "%d%%");
+		ImGui::SliderInt("Boost Limit ", &boostSettings.maxBoost, 0, 100, "%d%%");
 		ImGui::EndDisabled();
 	}
 	ImGui::Spacing();
@@ -86,10 +86,12 @@ void BoostMod::RenderSingleOption(BoostModValues& boostSettings)
 /// <summary>Renders the available options for the gamemode.</summary>
 void BoostMod::RenderOptions()
 {
-	// general modifier (everyone)
+	// general modifier (everyone), no ID
 	ImGui::Text("General:");
 	ImGui::Indent(20);
+
 	RenderSingleOption(generalBoostSettings);
+
 	ImGui::Unindent();
 
 	
@@ -97,11 +99,17 @@ void BoostMod::RenderOptions()
 	if (ImGui::CollapsingHeader("Team modifiers:")) {
 		ImGui::Indent(20);
 		for (int teamIdx = 0; teamIdx < teamsBoostSettings.size(); teamIdx++) {
-			if (ImGui::CollapsingHeader(teamsBoostSettings[teamIdx].displaySuffix.c_str())) {
+			ImGui::PushID(teamIdx);
+
+			if (ImGui::CollapsingHeader((" Team " + std::to_string(teamIdx)).c_str())) {
 				ImGui::Indent(20);
+
 				RenderSingleOption(teamsBoostSettings[teamIdx]);
+
 				ImGui::Unindent();
 			}
+
+			ImGui::PopID();
 		}
 		ImGui::Unindent();
 	}

--- a/source/gamemodes/BoostMod.cpp
+++ b/source/gamemodes/BoostMod.cpp
@@ -1,0 +1,138 @@
+// gamemodes/BoostMod.cpp
+// A general team based boost modifier gamemode for Rocket Plugin.
+// Credits to Stanbroek (rocket plugin author) 
+// and ubelhj (author of SpeedBoost plugin, source of some of the code here).
+// 
+// Author:       Al12
+// Version:      0.1.0 17/07/20
+// BMSDKversion: 95
+
+#include "BoostMod.h"
+
+
+/// <summary>Checks and updates boost every game tick.</summary>
+/// <remarks>Gets called on 'Function GameEvent_Soccar_TA.Active.Tick'.</remarks>
+/// <param name="server"><see cref="ServerWrapper"/> instance of the current server</param>
+/// <param name="params">Delay since last update</param>
+void BoostMod::onTick(ServerWrapper server, void* params)
+{
+	if (server.IsNull()) {
+		return;
+	}
+
+	float maxBoost = 1.0f;
+
+	if (generalBoostSettings.enabled) {
+		maxBoost = (float)generalBoostSettings.maxBoost / 100.0f;
+	}
+
+	auto teams = server.GetTeams();
+
+	for (int teamIdx = 0; teamIdx < teams.Count(); teamIdx++) {
+		float currentTeamMax = maxBoost;
+
+		if (teamIdx < teamsBoostSettings.size() && teamsBoostSettings[teamIdx].enabled) {
+			currentTeamMax = (float)teamsBoostSettings[teamIdx].maxBoost / 100.0f;
+		}
+		
+		if (generalBoostSettings.enabled || teamsBoostSettings[teamIdx].enabled) {
+			auto team = teams.Get(teamIdx);
+			if (team.IsNull()) { continue; }
+			auto players = team.GetMembers();
+
+			for (int playerIdx = 0; playerIdx < players.Count(); playerIdx++) {
+				auto player = players.Get(playerIdx);
+				if (player.IsNull()) { continue; }
+
+				auto car = player.GetCar();
+				if (car.IsNull()) { continue; }
+
+				auto boost = car.GetBoostComponent();
+				if (boost.IsNull()) { continue; }
+
+				if (boost.GetCurrentBoostAmount() > currentTeamMax) {
+					boost.SetBoostAmount(currentTeamMax);
+				}
+			}
+		}
+	}
+}
+
+/// Util function to render a single set of boost related options
+void BoostMod::RenderSingleOption(BoostModValues& boostSettings)
+{
+	ImGui::Spacing();
+	if (ImGui::SwitchCheckbox((" Enable " + boostSettings.displaySuffix).c_str(), 
+		boostSettings.enabled)) 
+	{
+		boostSettings.enabled = !boostSettings.enabled;
+	}
+	if (boostSettings.enabled) {
+		//TODO: implement boost amount type modifier.
+		//ImGui::SliderArray(("Boost Amount Type" + boostSettings.displaySuffix).c_str(), &boostSettings.boostAmountType, boostAmounts);
+		ImGui::SliderInt(("Boost Limit " + boostSettings.displaySuffix).c_str(),
+			&boostSettings.maxBoost, 0, 100, "%d%%");
+	}
+	else {
+		ImGui::BeginDisabled();
+		//ImGui::SliderArray(("Boost Amount Type" + boostSettings.displaySuffix).c_str(), &boostSettings.boostAmountType, boostAmounts);
+		ImGui::SliderInt(("Boost Limit " + boostSettings.displaySuffix).c_str(), &boostSettings.maxBoost, 0, 100, "%d%%");
+		ImGui::EndDisabled();
+	}
+	ImGui::Spacing();
+}
+
+/// <summary>Renders the available options for the gamemode.</summary>
+void BoostMod::RenderOptions()
+{
+	// general modifier (everyone)
+	ImGui::Text("General:");
+	ImGui::Indent(20);
+	RenderSingleOption(generalBoostSettings);
+	ImGui::Unindent();
+
+	
+	// team specific
+	if (ImGui::CollapsingHeader("Team modifiers:")) {
+		ImGui::Indent(20);
+		for (int teamIdx = 0; teamIdx < teamsBoostSettings.size(); teamIdx++) {
+			if (ImGui::CollapsingHeader(teamsBoostSettings[teamIdx].displaySuffix.c_str())) {
+				ImGui::Indent(20);
+				RenderSingleOption(teamsBoostSettings[teamIdx]);
+				ImGui::Unindent();
+			}
+		}
+		ImGui::Unindent();
+	}
+}
+
+
+/// <summary>Gets if the gamemode is active.</summary>
+/// <returns>Bool with if the gamemode is active</returns>
+bool BoostMod::IsActive()
+{
+	return isActive;
+}
+
+
+/// <summary>Activates the gamemode.</summary>
+void BoostMod::Activate(bool active)
+{
+	if (active && !isActive) {
+		HookEventWithCaller<ServerWrapper>("Function GameEvent_Soccar_TA.Active.Tick", std::bind(&BoostMod::onTick, this, std::placeholders::_1, std::placeholders::_2));
+	}
+	else if (!active && isActive) {
+		UnhookEvent("Function GameEvent_Soccar_TA.Active.Tick");
+		UnhookEvent("Function TAGame.VehiclePickup_Boost_TA.Pickup");
+	}
+
+	isActive = active;
+}
+
+
+/// <summary>Gets the gamemodes name.</summary>
+/// <returns>The gamemodes name</returns>
+std::string BoostMod::GetGamemodeName()
+{
+	return "Boost Mods";
+}

--- a/source/gamemodes/BoostMod.cpp
+++ b/source/gamemodes/BoostMod.cpp
@@ -35,7 +35,8 @@ void BoostMod::onTick(ServerWrapper server, void*)
 			currentTeamMax = (float)teamsBoostSettings[teamIdx].maxBoost / 100.0f;
 		}
 		
-		if (generalBoostSettings.enabled || teamsBoostSettings[teamIdx].enabled) {
+		if (generalBoostSettings.enabled || (teamIdx < teamsBoostSettings.size() 
+				&& teamsBoostSettings[teamIdx].enabled)) {
 			auto team = teams.Get(teamIdx);
 			if (team.IsNull()) { continue; }
 			auto players = team.GetMembers();

--- a/source/gamemodes/BoostMod.cpp
+++ b/source/gamemodes/BoostMod.cpp
@@ -104,6 +104,10 @@ void BoostMod::RenderOptions()
 		}
 		ImGui::Unindent();
 	}
+
+	ImGui::Separator();
+
+	ImGui::TextWrapped("Gamemode made by: AL12");
 }
 
 

--- a/source/gamemodes/BoostMod.cpp
+++ b/source/gamemodes/BoostMod.cpp
@@ -4,7 +4,7 @@
 // and ubelhj (author of SpeedBoost plugin, source of some of the code here).
 // 
 // Author:       Al12
-// Version:      0.1.0 17/07/20
+// Version:      0.1.1 28/07/20
 // BMSDKversion: 95
 
 #include "BoostMod.h"

--- a/source/gamemodes/BoostMod.cpp
+++ b/source/gamemodes/BoostMod.cpp
@@ -14,7 +14,7 @@
 /// <remarks>Gets called on 'Function GameEvent_Soccar_TA.Active.Tick'.</remarks>
 /// <param name="server"><see cref="ServerWrapper"/> instance of the current server</param>
 /// <param name="params">Delay since last update</param>
-void BoostMod::onTick(ServerWrapper server, void* params)
+void BoostMod::onTick(ServerWrapper server, void*)
 {
 	if (server.IsNull()) {
 		return;

--- a/source/gamemodes/BoostMod.h
+++ b/source/gamemodes/BoostMod.h
@@ -9,10 +9,6 @@ private:
 	void onTick(ServerWrapper server, void* params);
 
 	struct BoostModValues {
-		// A suffix to append to ui elements (ImGui uses the label to cache, so
-		// you can't have elements with the same labels.
-		std::string displaySuffix = "";
-
 		// Whether the modifier should be considered
 		bool enabled = false;
 
@@ -32,11 +28,11 @@ private:
 
 	const std::vector<std::string> boostAmounts = { "Default", "No Boost", "Unlimited", "Recharge (slow)", "Recharge (fast)" };
 
-	BoostModValues generalBoostSettings{"general", false, 100, 0};
+	BoostModValues generalBoostSettings{ false, 100, 0 };
 
 	std::vector<BoostModValues> teamsBoostSettings{ 
-		BoostModValues { "Team Blue", false, 100, 0 }, 
-		BoostModValues { "Team Orange", false, 100, 0 } };
+		BoostModValues { false, 100, 0 }, 
+		BoostModValues { false, 100, 0 } };
 
 public:
 	BoostMod(RocketPlugin* rp) : RocketGameMode(rp) { _typeid = std::make_shared<std::type_index>(typeid(*this)); }

--- a/source/gamemodes/BoostMod.h
+++ b/source/gamemodes/BoostMod.h
@@ -1,0 +1,51 @@
+#pragma once
+#include "../RocketPlugin.h"
+
+
+class BoostMod : public RocketGameMode
+{
+private:
+	float boostConversionPercentage = 100.0f;
+
+	void onTick(ServerWrapper server, void* params);
+	void OnBoostPickUp(ActorWrapper caller, void* params, std::string funcName);
+	void setMaxBoost(int newBoost);
+	std::vector<TeamWrapper> getTeams();
+
+	struct BoostModValues {
+		// A suffix to append to ui elements (ImGui uses the label to cache, so
+		// you can't have elements with the same labels.
+		std::string displaySuffix = "";
+
+		// Whether the modifier should be considered
+		bool enabled = false;
+
+		// Maximum amount of boost player can have. Range: 0-100
+		int maxBoost = 100;
+
+		// Type of boost:
+		// 0: default
+		// 1: no boost
+		// 2: unlimited
+		// 3: recharge (sloW)
+		// 4; recharge (fast)
+		std::size_t boostAmountType = 0;
+	};
+
+	void RenderSingleOption(BoostModValues& boostSettings);
+
+	const std::vector<std::string> boostAmounts = { "Default", "No Boost", "Unlimited", "Recharge (slow)", "Recharge (fast)" };
+
+	BoostModValues generalBoostSettings{"general", false, 100, 0};
+
+	std::vector<BoostModValues> teamsBoostSettings{ 
+		BoostModValues { "Team Blue", false, 100, 0 }, 
+		BoostModValues { "Team Orange", false, 100, 0 } };
+
+public:
+	BoostMod(RocketPlugin* rp) : RocketGameMode(rp) { _typeid = std::make_shared<std::type_index>(typeid(*this)); }
+	virtual void RenderOptions();
+	virtual bool IsActive();
+	virtual void Activate(bool active);
+	virtual std::string GetGamemodeName();
+};

--- a/source/gamemodes/BoostMod.h
+++ b/source/gamemodes/BoostMod.h
@@ -5,12 +5,8 @@
 class BoostMod : public RocketGameMode
 {
 private:
-	float boostConversionPercentage = 100.0f;
 
 	void onTick(ServerWrapper server, void* params);
-	void OnBoostPickUp(ActorWrapper caller, void* params, std::string funcName);
-	void setMaxBoost(int newBoost);
-	std::vector<TeamWrapper> getTeams();
 
 	struct BoostModValues {
 		// A suffix to append to ui elements (ImGui uses the label to cache, so


### PR DESCRIPTION
## Description
Added a new gameMode that allows users to change the max amount of boost players can use. The mod allows team specific settings to allow asymmetrical gameplay (champs vs scrubs).

## Changes proposed in this pull request
- Added two new files: BoostMod.cpp, BoostMod.h.
- Changed the solution to handle them.
- Edited RocketPlugin.cpp to include the new gamemode.

Things add later on:
- Allow options per player on each team instead of only teamwide. 
- Allow changing boost type (unlimited, recharge etc).
- Possibly other boost related modifiers...

Attention!
These changes have been tested in a local lobby by myself since I couldn't get my friends to join. It might be a good idea to test them on a lobby with more players before shipping.
