### PR TITLE
Set correct max players/team size on game init

### DIFF
--- a/source/RocketPlugin.cpp
+++ b/source/RocketPlugin.cpp
@@ -606,6 +606,8 @@ void RocketPlugin::gameEventInit(ServerWrapper server)
         return;
     }
 
+    setMaxPlayers(playerCount);
+    setMaxTeamSize((playerCount + 1) / 2);
     hostingGame = false;
     numBots = getNumBots();
 


### PR DESCRIPTION
Right now, the max players and team size resets on every map load. It was causing a bug when the "autofill with bots" was checked. Match was always 5v5 (or 6v6?) even if match was setup for less players than that in the rocket plugin UI.